### PR TITLE
mac issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ rfc
 target
 .cache
 Cargo.lock
+.DS_store


### PR DESCRIPTION
MacOS has a tendency putting a .DS_store in directories but this is just "decoration" and do not deserve a place in cross-platform repos.